### PR TITLE
bug #21 fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "14.x" # You might need to adjust this value to your own version
+          node-version: "18.x" # You might need to adjust this value to your own version
       - name: Build
         id: build
         run: |

--- a/src/main.ts
+++ b/src/main.ts
@@ -694,6 +694,15 @@ export default class CreasesPlugin extends Plugin {
     return pos
   }
 
+  private getFoldTargetPosition2(line: string): number {
+    let pos = line.length;
+    const blockIdExp = BLOCK_ID_REGEX.exec(line);
+    if (blockIdExp) {
+      pos = blockIdExp.index - 1;
+    }
+    return pos
+  }
+
   private async getCreasesFromFile(file: TFile): Promise<FoldPosition[]> {
     const fileContents = await this.app.vault.cachedRead(file);
     const fileLines = fileContents.split("\n");

--- a/src/main.ts
+++ b/src/main.ts
@@ -677,16 +677,21 @@ export default class CreasesPlugin extends Plugin {
         editor.replaceRange(lineWithoutCrease, from, to);
       } else {
         // Add Crease
-        let pos = line.length;
-        const blockIdExp = BLOCK_ID_REGEX.exec(line);
-        if (blockIdExp) {
-          pos = blockIdExp.index - 1;
-        }
-        const from = { line: lineNum, ch: pos };
-        const to = { line: lineNum, ch: pos };
+        const  foldTargetPosition = this.getFoldTargetPosition(line)
+        const from = { line: lineNum, ch: foldTargetPosition };
+        const to = { line: lineNum, ch: foldTargetPosition };
         editor.replaceRange(" %% fold %% ", from, to);
       }
     });
+  }
+
+  private getFoldTargetPosition(line: string): number {
+    let pos = line.length;
+    const blockIdExp = BLOCK_ID_REGEX.exec(line);
+    if (blockIdExp) {
+      pos = blockIdExp.index - 1;
+    }
+    return pos
   }
 
   private async getCreasesFromFile(file: TFile): Promise<FoldPosition[]> {
@@ -802,7 +807,7 @@ export default class CreasesPlugin extends Plugin {
     (existingFolds?.folds ?? []).forEach((fold) => {
       const line = editor.getLine(fold.from);
       if (!hasCrease(line)) {
-        const endOfLinePos = { line: fold.from, ch: line.length };
+        const endOfLinePos = { line: fold.from, ch: this.getFoldTargetPosition(line) };
         changes.push({
           text: " %% fold %%",
           from: endOfLinePos,


### PR DESCRIPTION
Hi!

This is a bug fix for [bug breaking block reference · Issue #21 · liamcain/obsidian-creases](https://github.com/liamcain/obsidian-creases/issues/21) like we said in the issue there was a need for consistency between the 2 functions so i refactored some logic in a new function getFoldTargetPosition to get consistent behavior (taking into account blockIDs) between toggleCrease and  creaseCurrentFolds.


This is my first contribution to an open source/github repo, so I hope everything is okay?

Fixes #21  

Thanks!