### PR TITLE
bug fix for #21

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -677,16 +677,21 @@ export default class CreasesPlugin extends Plugin {
         editor.replaceRange(lineWithoutCrease, from, to);
       } else {
         // Add Crease
-        let pos = line.length;
-        const blockIdExp = BLOCK_ID_REGEX.exec(line);
-        if (blockIdExp) {
-          pos = blockIdExp.index - 1;
-        }
-        const from = { line: lineNum, ch: pos };
-        const to = { line: lineNum, ch: pos };
+        const  foldTargetPosition = this.getFoldTargetPosition(line)
+        const from = { line: lineNum, ch: foldTargetPosition };
+        const to = { line: lineNum, ch: foldTargetPosition };
         editor.replaceRange(" %% fold %% ", from, to);
       }
     });
+  }
+
+  private getFoldTargetPosition(line: string): number {
+    let pos = line.length;
+    const blockIdExp = BLOCK_ID_REGEX.exec(line);
+    if (blockIdExp) {
+      pos = blockIdExp.index - 1;
+    }
+    return pos
   }
 
   private async getCreasesFromFile(file: TFile): Promise<FoldPosition[]> {
@@ -802,7 +807,7 @@ export default class CreasesPlugin extends Plugin {
     (existingFolds?.folds ?? []).forEach((fold) => {
       const line = editor.getLine(fold.from);
       if (!hasCrease(line)) {
-        const endOfLinePos = { line: fold.from, ch: line.length };
+        const endOfLinePos = { line: fold.from, ch: this.getFoldTargetPosition(line) };
         changes.push({
           text: " %% fold %%",
           from: endOfLinePos,


### PR DESCRIPTION
(correction of the last pr https://github.com/liamcain/obsidian-creases/pull/35 to only include necessary modification without package.json, yarn.lock)

Hi!

This is a bug fix for https://github.com/liamcain/obsidian-creases/issues/21 like we said in the issue there was a need for consistency between the 2 functions so i refactored some logic in a new function getFoldTargetPosition to get consistent behavior (taking into account blockIDs) between toggleCrease and creaseCurrentFolds.

This is my first contribution to an open source/github repo, so I hope everything is okay?

Fixes https://github.com/liamcain/obsidian-creases/issues/21

Thanks!