### PR TITLE
fix: preserve existing folds when inserting a template

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -218,7 +218,7 @@ export default class CreasesPlugin extends Plugin {
     const { view, newSelections, oldSelections } = evt;
     if (!view.editor) return;
 
-    const foldPositions: FoldRange[] = [];
+    const newFoldPositions: FoldRange[] = [];
     const changes: EditorChange[] = [];
 
     for (let idx = 0; idx < newSelections.length; idx++) {
@@ -238,7 +238,7 @@ export default class CreasesPlugin extends Plugin {
       for (let lineNum = start.line; lineNum <= end.line; lineNum++) {
         const line = view.editor.getLine(lineNum);
         if (hasCrease(line)) {
-          foldPositions.push({
+          newFoldPositions.push({
             from: lineNum,
             to: lineNum + 1,
           });
@@ -255,11 +255,25 @@ export default class CreasesPlugin extends Plugin {
       }
     }
 
-    view.editMode.applyFoldInfo({
-      folds: foldPositions,
-      lines: view.editor.lineCount(),
-    });
-    view.editor.transaction({ changes });
+    // Only touch fold state when the inserted template actually introduced
+    // creases. Otherwise calling applyFoldInfo with the (possibly empty) set
+    // of inserted-range folds would clobber every other fold in the document
+    // — most visibly, folds above the insertion point would spring open.
+    if (newFoldPositions.length > 0) {
+      const existingFolds = view.editMode.getFoldInfo()?.folds ?? [];
+      const foldsByLine = new Map<number, FoldRange>();
+      for (const fold of existingFolds) foldsByLine.set(fold.from, fold);
+      for (const fold of newFoldPositions) foldsByLine.set(fold.from, fold);
+
+      view.editMode.applyFoldInfo({
+        folds: Array.from(foldsByLine.values()),
+        lines: view.editor.lineCount(),
+      });
+    }
+
+    if (changes.length > 0) {
+      view.editor.transaction({ changes });
+    }
   }
 
   decreaseHeadingFoldLevel(ctx: MarkdownViewController) {


### PR DESCRIPTION
Fixes  #65 

Thanks for making this very useful plugin !  I am a fellow developer and brand new Obsidian user ( migrating away from Logseq ). 

 Trying to replicate my  daily timestamped log workflow ( using  Templater template  insertion bound to a hotkey)   I encountered bug #65  so  I used  Claude Code  to  investigate & generate this  fix.  

 I went through the generated code and it seems to be working ok in my use case but  I wasn't able to 100% verify the claims CC makes below  about  view.editMode.applyFoldInfo()  replacing full editor fold state - it seems to be an internal undocumented function. 

---
Before this commit, template insertion always called view.editMode.applyFoldInfo({ folds, lines }) using only folds found in the newly inserted template text.

Since applyFoldInfo replaces the full editor fold state, that accidentally removed all existing folds in the note. 

If the inserted template had no creases, it passed folds: [], which unfolded everything.

The fix does three things:

Renames foldPositions to newFoldPositions to make clear these are only folds introduced by the inserted template.

Applies fold info only when the inserted template actually introduced creases.

Merges current folds from view.editMode.getFoldInfo()?.folds with the new template folds, deduping by from line via a Map.
It also wraps view.editor.transaction({ changes }) in if (changes.length > 0), so no empty editor transaction is dispatched when there is nothing to edit.

Net effect: inserting a template no longer clears existing folds, while creases inside the inserted template still get folded.